### PR TITLE
Restrict bot to single test number

### DIFF
--- a/example.js
+++ b/example.js
@@ -35,7 +35,8 @@ client.on('loading_screen', (percent, message) => {
 let pairingCodeRequested = false;
 client.on('qr', async (qr) => {
     // NOTE: This event will not be fired if a session is specified.
-    console.log('QR RECEIVED');
+    console.log('Escanea este QR con WhatsApp:');
+    console.log(qr);
     qrcode.generate(qr, {small: true});
 
     // paiuting code example

--- a/example.js
+++ b/example.js
@@ -1,4 +1,5 @@
 const { Client, Location, Poll, List, Buttons, LocalAuth } = require('./index');
+const qrcode = require('qrcode-terminal');
 
 const client = new Client({
     authStrategy: new LocalAuth(),
@@ -34,7 +35,8 @@ client.on('loading_screen', (percent, message) => {
 let pairingCodeRequested = false;
 client.on('qr', async (qr) => {
     // NOTE: This event will not be fired if a session is specified.
-    console.log('QR RECEIVED', qr);
+    console.log('QR RECEIVED');
+    qrcode.generate(qr, {small: true});
 
     // paiuting code example
     const pairingCodeEnabled = false;

--- a/example.js
+++ b/example.js
@@ -3,11 +3,25 @@ const { Client, Location, Poll, List, Buttons, LocalAuth } = require('./index');
 const client = new Client({
     authStrategy: new LocalAuth(),
     // proxyAuthentication: { username: 'username', password: 'password' },
-    puppeteer: { 
+    puppeteer: {
         // args: ['--proxy-server=proxy-server-that-requires-authentication.example.com'],
         headless: false,
     }
 });
+
+// Allow sending messages only to a specific testing number
+const TEST_NUMBER = '573183495880';
+const ALLOWED_CHAT_ID = `${TEST_NUMBER}@c.us`;
+const originalSendMessage = client.sendMessage.bind(client);
+
+client.sendMessage = async (chatId, content, options = {}) => {
+    const normalized = chatId.replace(/@.*$/, '');
+    if (normalized !== TEST_NUMBER) {
+        console.log(`Message to ${chatId} blocked. Allowed number: ${ALLOWED_CHAT_ID}`);
+        return;
+    }
+    return originalSendMessage(ALLOWED_CHAT_ID, content, options);
+};
 
 // client initialize does not finish at ready now.
 client.initialize();

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "mime": "^3.0.0",
     "node-fetch": "^2.6.9",
     "node-webpmux": "3.1.7",
-    "puppeteer": "^18.2.1"
+    "puppeteer": "^18.2.1",
+    "qrcode-terminal": "^0.12.0"
   },
   "devDependencies": {
     "@types/node-fetch": "^2.5.12",


### PR DESCRIPTION
## Summary
- restrict example bot to send messages only to a test number

## Testing
- `npm install` *(fails: puppeteer download 403)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849abe72108832ba61bbf74221f7d4d